### PR TITLE
Update spam penalty function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,6 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "linebreak-style": ["error", "unix"],
-    // "formatOnSave": true
+    "formatOnSave": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,6 @@
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "linebreak-style": ["error", "unix"],
-    "formatOnSave": true
+    // "formatOnSave": true
   }
 }

--- a/test/TimeLockTest.js
+++ b/test/TimeLockTest.js
@@ -168,10 +168,10 @@ contract('TimeLock', ([appManager, accountBal1000, accountBal500, accountNoBalan
       })
     })
 
-    describe('getSpamPenalty()', () => {
+    describe('getSpamPenalty()', () => { 
       it("get's spam penalty amount and duration", async () => {
         const [actualSpamPenaltyAmount, actualSpamPenaltyDuration] = Object.values(
-          await timeLockForwarder.getSpamPenalty({ from: appManager })
+          await timeLockForwarder.getSpamPenalty(appManager)
         )
 
         assert.equal(actualSpamPenaltyAmount, 0)
@@ -195,7 +195,7 @@ contract('TimeLock', ([appManager, accountBal1000, accountBal500, accountNoBalan
 
         it('spam penalty amount and duration increase for second lock', async () => {
           const [actualSpamPenaltyAmount, actualSpamPenaltyDuration] = Object.values(
-            await timeLockForwarder.getSpamPenalty({ from: appManager })
+            await timeLockForwarder.getSpamPenalty(appManager)
           )
 
           assert.equal(actualSpamPenaltyAmount, bigExp(5, decimals).toString())
@@ -207,7 +207,7 @@ contract('TimeLock', ([appManager, accountBal1000, accountBal500, accountNoBalan
           await timeLockForwarder.changeSpamPenaltyFactor(pct16(100))
 
           const [actualSpamPenaltyAmount, actualSpamPenaltyDuration] = Object.values(
-            await timeLockForwarder.getSpamPenalty({ from: appManager })
+            await timeLockForwarder.getSpamPenalty(appManager)
           )
 
           assert.equal(actualSpamPenaltyAmount, bigExp(10, decimals).toString())


### PR DESCRIPTION
closes #65 closes #74 

Radspec PR has been merged https://github.com/aragon/radspec/pull/83 so now we could do something like `self.getSpamPenalty(msg.sender)` in the doc string. 

However, the client doesn't have this change yet so updated the doc string to use the contract address for now, so the evaluation wouldn't break.